### PR TITLE
Remove taskAttemptId from blockId

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -321,7 +321,7 @@ public class WriteBufferManager extends MemoryConsumer {
     }
     final long crc32 = ChecksumUtils.getCrc32(compressed);
     final long blockId =
-        ClientUtils.getBlockId(partitionId, taskAttemptId, getNextSeqNo(partitionId));
+        ClientUtils.getBlockId(partitionId, getNextSeqNo(partitionId));
     uncompressedDataLen += data.length;
     shuffleWriteMetrics.incBytesWritten(compressed.length);
     // add memory to indicate bytes which will be sent to shuffle server

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
@@ -106,7 +106,7 @@ public abstract class AbstractRssReaderTest extends HadoopTestBase {
         expectedData.put(key, value);
         writeData(serializeStream, key, value);
       }
-      long blockId = ClientUtils.getBlockId(partitionID, 0, atomicInteger.getAndIncrement());
+      long blockId = ClientUtils.getBlockId(partitionID, atomicInteger.getAndIncrement());
       blockIdBitmap.add(blockId);
       blocks.add(createShuffleBlock(output.toBytes(), blockId, compress));
       serializeStream.close();

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
@@ -81,7 +81,7 @@ public class RssShuffleDataIteratorTest extends AbstractRssReaderTest {
 
     validateResult(rssShuffleDataIterator, expectedData, 10);
 
-    blockIdBitmap.add(ClientUtils.getBlockId(0, 0, Constants.MAX_SEQUENCE_NO));
+    blockIdBitmap.add(ClientUtils.getBlockId(0, Constants.MAX_SEQUENCE_NO));
     rssShuffleDataIterator =
         getDataIterator(basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(ssi1));
     int recNum = 0;

--- a/client/src/main/java/org/apache/uniffle/client/util/ClientUtils.java
+++ b/client/src/main/java/org/apache/uniffle/client/util/ClientUtils.java
@@ -34,11 +34,10 @@ import org.apache.uniffle.storage.util.StorageType;
 
 public class ClientUtils {
 
-  // BlockId is long and composed of partitionId, executorId and AtomicInteger.
-  // AtomicInteger is first 19 bit, max value is 2^19 - 1
-  // partitionId is next 24 bit, max value is 2^24 - 1
-  // taskAttemptId is rest of 20 bit, max value is 2^20 - 1
-  public static Long getBlockId(long partitionId, long taskAttemptId, long atomicInt) {
+  // BlockId is positive long (63 bits used) and composed of partitionId and AtomicInteger.
+  // AtomicInteger is first 32 bit, max value is 2^31 - 1
+  // partitionId is rest of 31 bit, max value is 2^31 - 1
+  public static Long getBlockId(long partitionId, long atomicInt) {
     if (atomicInt < 0 || atomicInt > Constants.MAX_SEQUENCE_NO) {
       throw new IllegalArgumentException(
           "Can't support sequence["
@@ -53,16 +52,7 @@ public class ClientUtils {
               + "], the max value should be "
               + Constants.MAX_PARTITION_ID);
     }
-    if (taskAttemptId < 0 || taskAttemptId > Constants.MAX_TASK_ATTEMPT_ID) {
-      throw new IllegalArgumentException(
-          "Can't support taskAttemptId["
-              + taskAttemptId
-              + "], the max value should be "
-              + Constants.MAX_TASK_ATTEMPT_ID);
-    }
-    return (atomicInt << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
-        + (partitionId << Constants.TASK_ATTEMPT_ID_MAX_LENGTH)
-        + taskAttemptId;
+    return (atomicInt << Constants.PARTITION_ID_MAX_LENGTH) + partitionId;
   }
 
   public static RemoteStorageInfo fetchRemoteStorage(

--- a/client/src/main/java/org/apache/uniffle/client/util/DefaultIdHelper.java
+++ b/client/src/main/java/org/apache/uniffle/client/util/DefaultIdHelper.java
@@ -23,6 +23,7 @@ import org.apache.uniffle.common.util.IdHelper;
 public class DefaultIdHelper implements IdHelper {
   @Override
   public long getTaskAttemptId(long blockId) {
-    return blockId & Constants.MAX_TASK_ATTEMPT_ID;
+    // taskAttemptId has been removed from blockId, here partitionId serves as a proxy
+    return blockId & Constants.MAX_PARTITION_ID;
   }
 }

--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
@@ -91,8 +91,8 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     readClient.checkProcessedBlockIds();
     readClient.close();
 
-    blockIdBitmap.addLong(Constants.MAX_TASK_ATTEMPT_ID - 1);
-    taskIdBitmap.addLong(Constants.MAX_TASK_ATTEMPT_ID - 1);
+    blockIdBitmap.addLong(Constants.MAX_SEQUENCE_NO - 1);
+    taskIdBitmap.addLong(Constants.MAX_SEQUENCE_NO - 1);
     readClient =
         baseReadBuilder()
             .basePath(basePath)
@@ -377,7 +377,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     Roaring64NavigableMap wrongBlockIdBitmap = Roaring64NavigableMap.bitmapOf();
     LongIterator iter = blockIdBitmap.getLongIterator();
     while (iter.hasNext()) {
-      wrongBlockIdBitmap.addLong(iter.next() + (1 << Constants.TASK_ATTEMPT_ID_MAX_LENGTH));
+      wrongBlockIdBitmap.addLong(iter.next() + 1);
     }
 
     ShuffleReadClientImpl readClient =
@@ -585,10 +585,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     for (int i = 0; i < num; i++) {
       byte[] buf = new byte[length];
       new Random().nextBytes(buf);
-      long blockId =
-          (ATOMIC_LONG.getAndIncrement()
-                  << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
-              + taskAttemptId;
+      long blockId = ATOMIC_LONG.getAndIncrement() << Constants.PARTITION_ID_MAX_LENGTH;
       blocks.add(
           new ShufflePartitionedBlock(
               length, length, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf));
@@ -610,10 +607,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     for (int i = 0; i < num; i++) {
       byte[] buf = new byte[length];
       new Random().nextBytes(buf);
-      long blockId =
-          (ATOMIC_LONG.incrementAndGet()
-                  << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
-              + taskAttemptId;
+      long blockId = ATOMIC_LONG.incrementAndGet() << Constants.PARTITION_ID_MAX_LENGTH;
       ShufflePartitionedBlock spb =
           new ShufflePartitionedBlock(
               length, length, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf);

--- a/common/src/main/java/org/apache/uniffle/common/segment/FixedSizeSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/FixedSizeSegmentSplitter.java
@@ -89,7 +89,7 @@ public class FixedSizeSegmentSplitter implements SegmentSplitter {
                   + "This may happen when the data is flushing, please ignore.",
               totalLength,
               dataFileLen,
-              Math.toIntExact((blockId >> Constants.TASK_ATTEMPT_ID_MAX_LENGTH) & mask));
+              Math.toIntExact(blockId & mask));
           break;
         }
 

--- a/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
@@ -111,7 +111,7 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
                   + "This may happen when the data is flushing, please ignore.",
               totalLen,
               dataFileLen,
-              Math.toIntExact((blockId >> Constants.TASK_ATTEMPT_ID_MAX_LENGTH) & mask));
+              Math.toIntExact(blockId & mask));
           break;
         }
 

--- a/common/src/main/java/org/apache/uniffle/common/util/Constants.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/Constants.java
@@ -27,15 +27,12 @@ public final class Constants {
   public static final String COORDINATOR_TAG = "coordinator";
   public static final String SHUFFLE_DATA_FILE_SUFFIX = ".data";
   public static final String SHUFFLE_INDEX_FILE_SUFFIX = ".index";
-  // BlockId is long and consist of partitionId, taskAttemptId, atomicInt
-  // the length of them are ATOMIC_INT_MAX_LENGTH + PARTITION_ID_MAX_LENGTH +
-  // TASK_ATTEMPT_ID_MAX_LENGTH = 63
-  public static final int PARTITION_ID_MAX_LENGTH = 24;
-  public static final int TASK_ATTEMPT_ID_MAX_LENGTH = 21;
-  public static final int ATOMIC_INT_MAX_LENGTH = 18;
-  public static final long MAX_SEQUENCE_NO = (1 << Constants.ATOMIC_INT_MAX_LENGTH) - 1;
-  public static final long MAX_PARTITION_ID = (1 << Constants.PARTITION_ID_MAX_LENGTH) - 1;
-  public static final long MAX_TASK_ATTEMPT_ID = (1 << Constants.TASK_ATTEMPT_ID_MAX_LENGTH) - 1;
+  // BlockId is long and consist of partitionId and atomicInt
+  // the length of them are ATOMIC_INT_MAX_LENGTH + PARTITION_ID_MAX_LENGTH = 63
+  public static final int PARTITION_ID_MAX_LENGTH = 31;
+  public static final int ATOMIC_INT_MAX_LENGTH = 32;
+  public static final long MAX_SEQUENCE_NO = (1L << Constants.ATOMIC_INT_MAX_LENGTH) - 1;
+  public static final long MAX_PARTITION_ID = (1L << Constants.PARTITION_ID_MAX_LENGTH) - 1;
   public static final long INVALID_BLOCK_ID = -1L;
   public static final String KEY_SPLIT_CHAR = "/";
   public static final String COMMA_SPLIT_CHAR = ",";

--- a/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
@@ -338,7 +338,7 @@ public class RssUtils {
     long mask = (1L << Constants.PARTITION_ID_MAX_LENGTH) - 1;
     while (it.hasNext()) {
       Long blockId = it.next();
-      int partitionId = Math.toIntExact((blockId >> Constants.TASK_ATTEMPT_ID_MAX_LENGTH) & mask);
+      int partitionId = Math.toIntExact(blockId & mask);
       if (partitionId >= startPartition && partitionId < endPartition) {
         result.get(partitionId).add(blockId);
       }

--- a/common/src/test/java/org/apache/uniffle/common/util/RssUtilsTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/util/RssUtilsTest.java
@@ -229,14 +229,14 @@ public class RssUtilsTest {
   public void testShuffleBitmapToPartitionBitmap() {
     Roaring64NavigableMap partition1Bitmap =
         Roaring64NavigableMap.bitmapOf(
-            getBlockId(0, 0, 0), getBlockId(0, 0, 1), getBlockId(0, 1, 0), getBlockId(0, 1, 1));
+            getBlockId(0, 0), getBlockId(0, 1));
     Roaring64NavigableMap partition2Bitmap =
         Roaring64NavigableMap.bitmapOf(
-            getBlockId(1, 0, 0), getBlockId(1, 0, 1), getBlockId(1, 1, 0), getBlockId(1, 1, 1));
+            getBlockId(1, 0), getBlockId(1, 1));
     Roaring64NavigableMap shuffleBitmap = Roaring64NavigableMap.bitmapOf();
     shuffleBitmap.or(partition1Bitmap);
     shuffleBitmap.or(partition2Bitmap);
-    assertEquals(8, shuffleBitmap.getLongCardinality());
+    assertEquals(4, shuffleBitmap.getLongCardinality());
     Map<Integer, Roaring64NavigableMap> toPartitionBitmap =
         RssUtils.generatePartitionToBitmap(shuffleBitmap, 0, 2);
     assertEquals(2, toPartitionBitmap.size());
@@ -292,10 +292,8 @@ public class RssUtilsTest {
   }
 
   // Copy from ClientUtils
-  private Long getBlockId(long partitionId, long taskAttemptId, long atomicInt) {
-    return (atomicInt << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
-        + (partitionId << Constants.TASK_ATTEMPT_ID_MAX_LENGTH)
-        + taskAttemptId;
+  private Long getBlockId(long partitionId, long atomicInt) {
+    return (atomicInt << Constants.PARTITION_ID_MAX_LENGTH) + partitionId;
   }
 
   interface RssUtilTestDummy {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleReadWriteBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleReadWriteBase.java
@@ -64,9 +64,7 @@ public abstract class ShuffleReadWriteBase extends IntegrationTestBase {
       new Random().nextBytes(buf);
       long seqno = ATOMIC_LONG.getAndIncrement();
 
-      long blockId =
-          (seqno << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
-              + taskAttemptId;
+      long blockId = seqno << Constants.PARTITION_ID_MAX_LENGTH;
       blockIdBitmap.addLong(blockId);
       dataMap.put(blockId, buf);
       shuffleBlockInfoList.add(

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerGrpcTest.java
@@ -610,7 +610,7 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
           for (int i = 0; i < 100; i++) {
             Map<Integer, List<Long>> ptbs = Maps.newHashMap();
             List<Long> blockIds = Lists.newArrayList();
-            Long blockId = ClientUtils.getBlockId(1, 0, i);
+            Long blockId = ClientUtils.getBlockId(1, i);
             expectedBlockIds.add(blockId);
             blockIds.add(blockId);
             ptbs.put(1, blockIds);
@@ -624,7 +624,7 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
           for (int i = 100; i < 200; i++) {
             Map<Integer, List<Long>> ptbs = Maps.newHashMap();
             List<Long> blockIds = Lists.newArrayList();
-            Long blockId = ClientUtils.getBlockId(1, 1, i);
+            Long blockId = ClientUtils.getBlockId(1, i);
             expectedBlockIds.add(blockId);
             blockIds.add(blockId);
             ptbs.put(1, blockIds);
@@ -638,7 +638,7 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
           for (int i = 200; i < 300; i++) {
             Map<Integer, List<Long>> ptbs = Maps.newHashMap();
             List<Long> blockIds = Lists.newArrayList();
-            Long blockId = ClientUtils.getBlockId(1, 2, i);
+            Long blockId = ClientUtils.getBlockId(1, i);
             expectedBlockIds.add(blockId);
             blockIds.add(blockId);
             ptbs.put(1, blockIds);
@@ -984,7 +984,7 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
   private List<Long> getBlockIdList(int partitionId, int blockNum) {
     List<Long> blockIds = Lists.newArrayList();
     for (int i = 0; i < blockNum; i++) {
-      blockIds.add(ClientUtils.getBlockId(partitionId, 0, atomicInteger.getAndIncrement()));
+      blockIds.add(ClientUtils.getBlockId(partitionId, atomicInteger.getAndIncrement()));
     }
     return blockIds;
   }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
@@ -204,7 +204,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
 
     int partitionIdx = 1;
     for (int i = 0; i < 5; i++) {
-      blockIds.add(ClientUtils.getBlockId(partitionIdx, 0, i));
+      blockIds.add(ClientUtils.getBlockId(partitionIdx, i));
     }
     partitionToBlocks.put(partitionIdx, blockIds);
 
@@ -253,12 +253,12 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
     Map<Integer, List<Long>> partitionToBlocks = Maps.newHashMap();
     List<Long> blockIds = Lists.newArrayList();
     for (int i = 0; i < 5; i++) {
-      blockIds.add(ClientUtils.getBlockId(1, 0, i));
+      blockIds.add(ClientUtils.getBlockId(1, i));
     }
     partitionToBlocks.put(1, blockIds);
     blockIds = Lists.newArrayList();
     for (int i = 0; i < 7; i++) {
-      blockIds.add(ClientUtils.getBlockId(2, 0, i));
+      blockIds.add(ClientUtils.getBlockId(2, i));
     }
     partitionToBlocks.put(2, blockIds);
     shuffleWriteClientImpl.reportShuffleResult(

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkClientWithLocalTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkClientWithLocalTest.java
@@ -105,7 +105,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     createTestData(testAppId, expectedData, blockIdBitmap, taskIdBitmap);
-    blockIdBitmap.addLong((1 << Constants.TASK_ATTEMPT_ID_MAX_LENGTH));
+    blockIdBitmap.addLong(3L << Constants.PARTITION_ID_MAX_LENGTH);
     ShuffleReadClientImpl readClient;
     readClient =
         baseReadBuilder()
@@ -252,7 +252,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     Roaring64NavigableMap wrongBlockIdBitmap = Roaring64NavigableMap.bitmapOf();
     LongIterator iter = blockIdBitmap.getLongIterator();
     while (iter.hasNext()) {
-      wrongBlockIdBitmap.addLong(iter.next() + (1 << Constants.TASK_ATTEMPT_ID_MAX_LENGTH));
+      wrongBlockIdBitmap.addLong(iter.next() + 1);
     }
 
     ShuffleReadClientImpl readClient =

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -560,7 +560,7 @@ public class ShuffleTaskManager {
     bitmap.forEach(
         blockId -> {
           int partitionId =
-              Math.toIntExact((blockId >> Constants.TASK_ATTEMPT_ID_MAX_LENGTH) & mask);
+              Math.toIntExact(blockId & mask);
           if (requestPartitions.contains(partitionId)) {
             resultBitmap.addLong(blockId);
           }

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -713,7 +713,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     for (int taskId = 1; taskId < 10; taskId++) {
       for (int partitionId = 1; partitionId < 10; partitionId++) {
         for (int i = 0; i < 2; i++) {
-          long blockId = getBlockId(partitionId, taskId, i);
+          long blockId = getBlockId(partitionId, i);
           bitmapBlockIds.addLong(blockId);
           if (partitionId == expectedPartitionId) {
             expectedBlockIds.addLong(blockId);
@@ -726,15 +726,14 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
             Sets.newHashSet(expectedPartitionId), bitmapBlockIds, Roaring64NavigableMap.bitmapOf());
     assertEquals(expectedBlockIds, resultBlockIds);
 
-    bitmapBlockIds.addLong(getBlockId(0, 0, 0));
+    bitmapBlockIds.addLong(getBlockId(0, 0));
     resultBlockIds =
         shuffleTaskManager.getBlockIdsByPartitionId(
             Sets.newHashSet(0), bitmapBlockIds, Roaring64NavigableMap.bitmapOf());
     assertEquals(Roaring64NavigableMap.bitmapOf(0L), resultBlockIds);
 
     long expectedBlockId =
-        getBlockId(
-            Constants.MAX_PARTITION_ID, Constants.MAX_TASK_ATTEMPT_ID, Constants.MAX_SEQUENCE_NO);
+        getBlockId(Constants.MAX_PARTITION_ID, Constants.MAX_SEQUENCE_NO);
     bitmapBlockIds.addLong(expectedBlockId);
     resultBlockIds =
         shuffleTaskManager.getBlockIdsByPartitionId(
@@ -756,7 +755,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     for (int taskId = 1; taskId < 10; taskId++) {
       for (int partitionId = 1; partitionId < 10; partitionId++) {
         for (int i = 0; i < 2; i++) {
-          long blockId = getBlockId(partitionId, taskId, i);
+          long blockId = getBlockId(partitionId, i);
           bitmapBlockIds.addLong(blockId);
           if (partitionId >= startPartition && partitionId <= endPartition) {
             expectedBlockIds.addLong(blockId);
@@ -829,7 +828,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
       long[] blockIds = new long[taskNum * blocksPerTask];
       for (int taskId = 0; taskId < taskNum; taskId++) {
         for (int i = 0; i < blocksPerTask; i++) {
-          long blockId = getBlockId(partitionId, taskId, i);
+          long blockId = getBlockId(partitionId, i);
           blockIds[taskId * blocksPerTask + i] = blockId;
         }
       }
@@ -985,10 +984,8 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
   }
 
   // copy from ClientUtils
-  private Long getBlockId(long partitionId, long taskAttemptId, long atomicInt) {
-    return (atomicInt << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
-        + (partitionId << Constants.TASK_ATTEMPT_ID_MAX_LENGTH)
-        + taskAttemptId;
+  private Long getBlockId(long partitionId, long atomicInt) {
+    return (atomicInt << Constants.PARTITION_ID_MAX_LENGTH) + partitionId;
   }
 
   private void waitForFlush(

--- a/storage/src/test/java/org/apache/uniffle/storage/HadoopShuffleHandlerTestBase.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/HadoopShuffleHandlerTestBase.java
@@ -56,10 +56,7 @@ public class HadoopShuffleHandlerTestBase {
     for (int i = 0; i < num; i++) {
       byte[] buf = new byte[length];
       new Random().nextBytes(buf);
-      long blockId =
-          (ATOMIC_LONG.getAndIncrement()
-                  << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
-              + taskAttemptId;
+      long blockId = ATOMIC_LONG.getAndIncrement() << Constants.PARTITION_ID_MAX_LENGTH;
       blocks.add(
           new ShufflePartitionedBlock(
               length, length, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf));
@@ -84,10 +81,7 @@ public class HadoopShuffleHandlerTestBase {
     for (int i = 0; i < num; i++) {
       byte[] buf = new byte[length];
       new Random().nextBytes(buf);
-      long blockId =
-          (ATOMIC_LONG.getAndIncrement()
-                  << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
-              + taskAttemptId;
+      long blockId = ATOMIC_LONG.getAndIncrement() << Constants.PARTITION_ID_MAX_LENGTH;
       blocks.add(
           new ShufflePartitionedBlock(
               length, length, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf));

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleReadHandlerTest.java
@@ -118,10 +118,7 @@ public class HadoopShuffleReadHandlerTest extends HadoopTestBase {
     List<ShufflePartitionedBlock> blocks = Lists.newArrayList();
     byte[] buf = new byte[blockSize];
     new Random().nextBytes(buf);
-    long blockId =
-        (expectTotalBlockNum
-                << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
-            + taskAttemptId;
+    long blockId = (long)expectTotalBlockNum << Constants.PARTITION_ID_MAX_LENGTH;
     blocks.add(
         new ShufflePartitionedBlock(
             blockSize, blockSize, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf));


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removes `taskAttemptId` from `blockId`.

### Why are the changes needed?
With `taskAttemptId`, the `blockId` can accompany the entire partitionId (positive int) and a sequence number of 32 bit.

Fix: https://github.com/apache/incubator-uniffle/issues/134

### Does this PR introduce _any_ user-facing change?
This requires Spark apps to update dependencies.

### How was this patch tested?
Tests