### PR TITLE
[#731][FOLLOWUP] feat(Spark): Configure blockIdLayout for Spark based on max partitions

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -373,6 +373,15 @@ public class RssSparkConfig {
                   .doc("Whether to enable the resubmit stage."))
           .createWithDefault(false);
 
+  public static final ConfigEntry<Integer> RSS_MAX_PARTITIONS =
+      createIntegerBuilder(
+              new ConfigBuilder("spark.rss.blockId.maxPartitions")
+                  .doc(
+                      "Sets the maximum number of partitions to be supported by block ids. "
+                          + "This determines the bits reserved in block ids for the "
+                          + "sequence number, the partition id and the task attempt id."))
+          .createWithDefault(1048576);
+
   // spark2 doesn't have this key defined
   public static final String SPARK_SHUFFLE_COMPRESS_KEY = "spark.shuffle.compress";
 

--- a/common/src/main/java/org/apache/uniffle/common/util/BlockIdLayout.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/BlockIdLayout.java
@@ -30,7 +30,8 @@ import org.apache.uniffle.common.config.RssConf;
  * Values of partitionId, taskAttemptId and AtomicInteger are always positive.
  */
 public class BlockIdLayout {
-
+  // historic default values, client-specific config defaults may vary
+  // see RssSparkConfig
   public static final int DEFAULT_SEQUENCE_NO_BITS = 18;
   public static final int DEFAULT_PARTITION_ID_BITS = 24;
   public static final int DEFAULT_TASK_ATTEMPT_ID_BITS = 21;

--- a/docs/client_guide/spark_client_guide.md
+++ b/docs/client_guide/spark_client_guide.md
@@ -90,7 +90,8 @@ The important configuration is listed as following.
 
 ### Block id bits
 
-If you observe an error like
+The default bits reserved in the block id are client-type agnostic. To maximize the bit utilization for Spark3 clients,
+adopt the following considerations. Also, if you observe an error like
 
     Don't support sequenceNo[…], the max value should be …
     Don't support partitionId[…], the max value should be …

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RssShuffleManagerTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RssShuffleManagerTest.java
@@ -107,6 +107,7 @@ public class RssShuffleManagerTest extends SparkIntegrationTestBase {
     return new HashMap();
   }
 
+  private static final BlockIdLayout DEFAULT = BlockIdLayout.from(21, 20, 22);
   private static final BlockIdLayout CUSTOM1 = BlockIdLayout.from(20, 21, 22);
   private static final BlockIdLayout CUSTOM2 = BlockIdLayout.from(22, 18, 23);
 
@@ -117,7 +118,7 @@ public class RssShuffleManagerTest extends SparkIntegrationTestBase {
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   public void testRssShuffleManager(boolean enableDynamicClientConf) throws Exception {
-    doTestRssShuffleManager(null, null, BlockIdLayout.DEFAULT, enableDynamicClientConf);
+    doTestRssShuffleManager(null, null, DEFAULT, enableDynamicClientConf);
   }
 
   @ParameterizedTest
@@ -191,6 +192,7 @@ public class RssShuffleManagerTest extends SparkIntegrationTestBase {
       // get written block ids (we know there is one shuffle where two task attempts wrote two
       // partitions)
       RssConf rssConf = RssSparkConfig.toRssConf(conf);
+      shuffleManager.configureBlockIdLayout(conf, rssConf);
       ShuffleWriteClient shuffleWriteClient =
           ShuffleClientFactory.newWriteBuilder()
               .clientType(ClientType.GRPC.name())


### PR DESCRIPTION
### What changes were proposed in this pull request?
The configuration of the block id layout for Spark2 and Spark3 can be simplified by only providing the maximal number of partitions.

### Why are the changes needed?
Currently, optimally configuring the block id layout for Spark is quite complex: https://github.com/apache/incubator-uniffle/pull/1528/files#diff-09ce7eaa98815d62ca00b2a8b0a45b0a922b047014c1f91dc17081b3fef8e7a8R101-R109

Three values have to be provided: the number of bits for sequence number, partition id and task attempt id. The task attempt id has to provide more bits than the partition id, in the sense that the maximal number of attempts can be stored. This requires to also account for speculative execution.

The RssShuffleManager can do the computation and derive the optimal block id layout configuration from the maximal number of partitions only.

### Does this PR introduce _any_ user-facing change?
Adds optional configuration `spark.rss.blockId.maxPartitions`.

### How was this patch tested?
Unit and integration tests.