### PR TITLE
[#1621][#1399] refactor: Report blockids as number of blocks

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -249,6 +249,7 @@ public class RssSparkConfig {
       createStringBuilder(new ConfigBuilder("spark.rss.ozone.fs.AbstractFileSystem.hdfs.impl"))
           .createWithDefault("org.apache.hadoop.odfs.HdfsOdfs");
 
+  // TODO: deprecate
   public static final ConfigEntry<Integer> RSS_CLIENT_BITMAP_SPLIT_NUM =
       createIntegerBuilder(new ConfigBuilder("spark.rss.client.bitmap.splitNum"))
           .createWithDefault(1);

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -358,6 +358,10 @@ public class WriteBufferManager extends MemoryConsumer {
     return seqNo;
   }
 
+  public Map<Integer, Integer> getPartitionBlockNums() {
+    return partitionToSeqNo;
+  }
+
   private void requestMemory(long requiredMem) {
     final long start = System.currentTimeMillis();
     if (allocatedBytes.get() - usedBytes.get() < requiredMem) {

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/client/RssClientUtils.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/client/RssClientUtils.java
@@ -15,29 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.client.request;
+package org.apache.uniffle.shuffle.client;
 
-public class RssGetShuffleResultRequest {
+import java.util.Map;
 
-  private String appId;
-  private int shuffleId;
-  private int partitionId;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
-  public RssGetShuffleResultRequest(String appId, int shuffleId, int partitionId) {
-    this.appId = appId;
-    this.shuffleId = shuffleId;
-    this.partitionId = partitionId;
-  }
+import org.apache.uniffle.common.util.BlockIdLayout;
 
-  public String getAppId() {
-    return appId;
-  }
-
-  public int getShuffleId() {
-    return shuffleId;
-  }
-
-  public int getPartitionId() {
-    return partitionId;
+public class RssClientUtils {
+  public static Roaring64NavigableMap createBlockIdBitmap(
+      int partitionId, Map<Long, Integer> blocks, BlockIdLayout blockIdLayout) {
+    Roaring64NavigableMap bitmap = Roaring64NavigableMap.bitmapOf();
+    blocks.forEach(
+        (taskAttemptId, blockNum) -> {
+          for (int sequenceNo = 0; sequenceNo < blockNum; sequenceNo++) {
+            long blockId = blockIdLayout.getBlockId(sequenceNo, partitionId, taskAttemptId);
+            bitmap.add(blockId);
+          }
+        });
+    return bitmap;
   }
 }

--- a/client-spark/common/src/test/java/org/apache/uniffle/shuffle/client/RssClientUtilsTest.java
+++ b/client-spark/common/src/test/java/org/apache/uniffle/shuffle/client/RssClientUtilsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.shuffle.client;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import scala.Console;
+
+import com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import org.apache.uniffle.common.util.BlockIdLayout;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class RssClientUtilsTest {
+  @Test
+  public void createBlockIdBitmapTest() {
+    BlockIdLayout layout = BlockIdLayout.DEFAULT;
+
+    // no blocks
+    Map<Long, Integer> blocks = Maps.newHashMap();
+    long[] expecteds = new long[] {};
+    Roaring64NavigableMap bitmap = RssClientUtils.createBlockIdBitmap(1, blocks, layout);
+    assertArrayEquals(expecteds, bitmap.toArray());
+
+    // zero blocks for one task attempt id
+    blocks.put(2L, 0);
+    expecteds = new long[] {};
+    bitmap = RssClientUtils.createBlockIdBitmap(1, blocks, layout);
+    assertArrayEquals(expecteds, bitmap.toArray());
+
+    // one block for one task attempt id
+    blocks.put(2L, 1);
+    expecteds = new long[] {layout.getBlockId(0, 1, 2)};
+    bitmap = RssClientUtils.createBlockIdBitmap(1, blocks, layout);
+    assertArrayEquals(expecteds, bitmap.toArray());
+
+    // twp blocks for one task attempt id
+    blocks.put(2L, 2);
+    expecteds = new long[] {layout.getBlockId(0, 1, 2), layout.getBlockId(1, 1, 2)};
+    bitmap = RssClientUtils.createBlockIdBitmap(1, blocks, layout);
+    assertArrayEquals(expecteds, bitmap.toArray());
+
+    // twp blocks for one task attempt id, and one for another task attempt id
+    blocks.put(3L, 1);
+    expecteds =
+        new long[] {
+          layout.getBlockId(0, 1, 2), layout.getBlockId(0, 1, 3), layout.getBlockId(1, 1, 2)
+        };
+    bitmap = RssClientUtils.createBlockIdBitmap(1, blocks, layout);
+    assertArrayEquals(expecteds, bitmap.toArray());
+
+    // different partition id
+    expecteds =
+        new long[] {
+          layout.getBlockId(0, 3, 2), layout.getBlockId(0, 3, 3), layout.getBlockId(1, 3, 2)
+        };
+    bitmap = RssClientUtils.createBlockIdBitmap(3, blocks, layout);
+    final BlockIdLayout l = layout;
+    Console.print(
+        bitmap.stream().mapToObj(e -> l.asBlockId(e).toString()).collect(Collectors.joining(", ")));
+    assertArrayEquals(expecteds, bitmap.toArray());
+
+    // different layout
+    layout = BlockIdLayout.from(20, 21, 22);
+    expecteds =
+        new long[] {
+          layout.getBlockId(0, 1, 2), layout.getBlockId(0, 1, 3), layout.getBlockId(1, 1, 2)
+        };
+    bitmap = RssClientUtils.createBlockIdBitmap(1, blocks, layout);
+    assertArrayEquals(expecteds, bitmap.toArray());
+  }
+}

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-
 import org.apache.uniffle.client.PartitionDataReplicaRequirementTracking;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.common.PartitionRange;
@@ -63,11 +61,11 @@ public interface ShuffleWriteClient {
   RemoteStorageInfo fetchRemoteStorage(String appId);
 
   void reportShuffleResult(
-      Map<ShuffleServerInfo, Map<Integer, Set<Long>>> serverToPartitionToBlockIds,
+      Map<Integer, Integer> partitionToBlockNum,
+      Map<ShuffleServerInfo, Map<Integer, Set<Long>>> serverToPartitionToBlocks,
       String appId,
       int shuffleId,
-      long taskAttemptId,
-      int bitmapNum);
+      long taskAttemptId);
 
   default ShuffleAssignmentsInfo getShuffleAssignments(
       String appId,
@@ -92,14 +90,14 @@ public interface ShuffleWriteClient {
       int assignmentShuffleServerNumber,
       int estimateTaskConcurrency);
 
-  Roaring64NavigableMap getShuffleResult(
+  Map<Long, Integer> getShuffleResult(
       String clientType,
       Set<ShuffleServerInfo> shuffleServerInfoSet,
       String appId,
       int shuffleId,
       int partitionId);
 
-  Roaring64NavigableMap getShuffleResultForMultiPart(
+  Map<Long, Map<Integer, Integer>> getShuffleResultForMultiPart(
       String clientType,
       Map<ShuffleServerInfo, Set<Integer>> serverToPartitions,
       String appId,

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageFaultToleranceBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageFaultToleranceBase.java
@@ -17,7 +17,6 @@
 
 package org.apache.uniffle.test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -145,11 +144,11 @@ public abstract class HybridStorageFaultToleranceBase extends ShuffleReadWriteBa
     shuffleServerClient.sendCommit(rc);
     shuffleServerClient.finishShuffle(rf);
 
-    Map<Integer, List<Long>> partitionToBlockIds = Maps.newHashMap();
+    Map<Integer, Integer> partitionToBlockNum = Maps.newHashMap();
     Set<Long> expectBlockIds = getExpectBlockIds(blocks);
-    partitionToBlockIds.put(shuffle, new ArrayList<>(expectBlockIds));
+    partitionToBlockNum.put(partition, expectBlockIds.size());
     RssReportShuffleResultRequest rrp =
-        new RssReportShuffleResultRequest(appId, shuffle, taskAttemptId, partitionToBlockIds, 1);
+        new RssReportShuffleResultRequest(appId, shuffle, taskAttemptId, partitionToBlockNum);
     shuffleServerClient.reportShuffleResult(rrp);
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RpcClientRetryTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RpcClientRetryTest.java
@@ -148,7 +148,7 @@ public class RpcClientRetryTest extends ShuffleReadWriteBase {
   @ParameterizedTest
   @MethodSource("testRpcRetryLogicProvider")
   public void testRpcRetryLogic(StorageType storageType) {
-    String testAppId = "testRpcRetryLogic";
+    String testAppId = "testRpcRetryLogic-" + storageType;
     registerShuffleServer(testAppId, 3, 2, 2, true);
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
@@ -185,10 +185,10 @@ public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
 
     List<ShuffleServer> shuffleServers = isNettyMode ? nettyShuffleServers : grpcShuffleServers;
     assertNotNull(
-        shuffleServers.get(0).getShuffleTaskManager().getPartitionsToBlockIds().get(testAppId));
+        shuffleServers.get(0).getShuffleTaskManager().getPartitionsToBlocks().get(testAppId));
     Thread.sleep(8000);
     assertNull(
-        shuffleServers.get(0).getShuffleTaskManager().getPartitionsToBlockIds().get(testAppId));
+        shuffleServers.get(0).getShuffleTaskManager().getPartitionsToBlocks().get(testAppId));
   }
 
   protected void validateResult(

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionWithLocalFileRssTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionWithLocalFileRssTest.java
@@ -37,6 +37,7 @@ import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
 import static org.apache.uniffle.common.config.RssClientConf.COMPRESSION_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RepartitionWithLocalFileRssTest extends RepartitionTest {
 
@@ -85,7 +86,7 @@ public class RepartitionWithLocalFileRssTest extends RepartitionTest {
     }
 
     for (int i = 1; i < results.size(); i++) {
-      verifyTestResult(results.get(0), results.get(i));
+      assertEquals(results.get(0), results.get(i));
     }
   }
 }

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkIntegrationTestBase.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkIntegrationTestBase.java
@@ -64,8 +64,8 @@ public abstract class SparkIntegrationTestBase extends IntegrationTestBase {
     start = System.currentTimeMillis();
     Map resultWithRssNetty = runSparkApp(sparkConf, fileName);
     final long durationWithRssNetty = System.currentTimeMillis() - start;
-    verifyTestResult(resultWithoutRss, resultWithRss);
-    verifyTestResult(resultWithoutRss, resultWithRssNetty);
+    assertEquals(resultWithoutRss, resultWithRss);
+    assertEquals(resultWithoutRss, resultWithRssNetty);
 
     LOG.info(
         "Test: durationWithoutRss["
@@ -122,12 +122,5 @@ public abstract class SparkIntegrationTestBase extends IntegrationTestBase {
 
   public void updateSparkConfWithRssNetty(SparkConf sparkConf) {
     sparkConf.set(RssSparkConfig.RSS_CLIENT_TYPE, "GRPC_NETTY");
-  }
-
-  protected void verifyTestResult(Map expected, Map actual) {
-    assertEquals(expected.size(), actual.size());
-    for (Object expectedKey : expected.keySet()) {
-      assertEquals(expected.get(expectedKey), actual.get(expectedKey));
-    }
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleServerClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleServerClient.java
@@ -35,6 +35,7 @@ import org.apache.uniffle.client.response.RssFinishShuffleResponse;
 import org.apache.uniffle.client.response.RssGetInMemoryShuffleDataResponse;
 import org.apache.uniffle.client.response.RssGetShuffleDataResponse;
 import org.apache.uniffle.client.response.RssGetShuffleIndexResponse;
+import org.apache.uniffle.client.response.RssGetShuffleResultForMultiPartResponse;
 import org.apache.uniffle.client.response.RssGetShuffleResultResponse;
 import org.apache.uniffle.client.response.RssRegisterShuffleResponse;
 import org.apache.uniffle.client.response.RssReportShuffleResultResponse;
@@ -64,7 +65,7 @@ public interface ShuffleServerClient {
 
   RssGetShuffleResultResponse getShuffleResult(RssGetShuffleResultRequest request);
 
-  RssGetShuffleResultResponse getShuffleResultForMultiPart(
+  RssGetShuffleResultForMultiPartResponse getShuffleResultForMultiPart(
       RssGetShuffleResultForMultiPartRequest request);
 
   RssGetShuffleIndexResponse getShuffleIndex(RssGetShuffleIndexRequest request);

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssGetShuffleResultForMultiPartRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssGetShuffleResultForMultiPartRequest.java
@@ -19,20 +19,16 @@ package org.apache.uniffle.client.request;
 
 import java.util.Set;
 
-import org.apache.uniffle.common.util.BlockIdLayout;
-
 public class RssGetShuffleResultForMultiPartRequest {
   private String appId;
   private int shuffleId;
   private Set<Integer> partitions;
-  private BlockIdLayout blockIdLayout;
 
   public RssGetShuffleResultForMultiPartRequest(
-      String appId, int shuffleId, Set<Integer> partitions, BlockIdLayout blockIdLayout) {
+      String appId, int shuffleId, Set<Integer> partitions) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitions = partitions;
-    this.blockIdLayout = blockIdLayout;
   }
 
   public String getAppId() {
@@ -45,9 +41,5 @@ public class RssGetShuffleResultForMultiPartRequest {
 
   public Set<Integer> getPartitions() {
     return partitions;
-  }
-
-  public BlockIdLayout getBlockIdLayout() {
-    return blockIdLayout;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleResultRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleResultRequest.java
@@ -17,7 +17,6 @@
 
 package org.apache.uniffle.client.request;
 
-import java.util.List;
 import java.util.Map;
 
 public class RssReportShuffleResultRequest {
@@ -25,20 +24,14 @@ public class RssReportShuffleResultRequest {
   private String appId;
   private int shuffleId;
   private long taskAttemptId;
-  private int bitmapNum;
-  private Map<Integer, List<Long>> partitionToBlockIds;
+  private Map<Integer, Integer> partitionToBlocks;
 
   public RssReportShuffleResultRequest(
-      String appId,
-      int shuffleId,
-      long taskAttemptId,
-      Map<Integer, List<Long>> partitionToBlockIds,
-      int bitmapNum) {
+      String appId, int shuffleId, long taskAttemptId, Map<Integer, Integer> partitionToBlocks) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.taskAttemptId = taskAttemptId;
-    this.bitmapNum = bitmapNum;
-    this.partitionToBlockIds = partitionToBlockIds;
+    this.partitionToBlocks = partitionToBlocks;
   }
 
   public String getAppId() {
@@ -53,11 +46,7 @@ public class RssReportShuffleResultRequest {
     return taskAttemptId;
   }
 
-  public int getBitmapNum() {
-    return bitmapNum;
-  }
-
-  public Map<Integer, List<Long>> getPartitionToBlockIds() {
-    return partitionToBlockIds;
+  public Map<Integer, Integer> getPartitionToBlocks() {
+    return partitionToBlocks;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssGetShuffleResultForMultiPartResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssGetShuffleResultForMultiPartResponse.java
@@ -15,29 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.client.request;
+package org.apache.uniffle.client.response;
 
-public class RssGetShuffleResultRequest {
+import java.util.Map;
 
-  private String appId;
-  private int shuffleId;
-  private int partitionId;
+import org.apache.uniffle.common.rpc.StatusCode;
 
-  public RssGetShuffleResultRequest(String appId, int shuffleId, int partitionId) {
-    this.appId = appId;
-    this.shuffleId = shuffleId;
-    this.partitionId = partitionId;
+public class RssGetShuffleResultForMultiPartResponse extends ClientResponse {
+
+  private Map<Long, Map<Integer, Integer>> blocks;
+
+  public RssGetShuffleResultForMultiPartResponse(
+      StatusCode statusCode, Map<Long, Map<Integer, Integer>> blocks) {
+    super(statusCode);
+    this.blocks = blocks;
   }
 
-  public String getAppId() {
-    return appId;
-  }
-
-  public int getShuffleId() {
-    return shuffleId;
-  }
-
-  public int getPartitionId() {
-    return partitionId;
+  public Map<Long, Map<Integer, Integer>> getBlocks() {
+    return blocks;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssGetShuffleResultResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssGetShuffleResultResponse.java
@@ -17,24 +17,20 @@
 
 package org.apache.uniffle.client.response;
 
-import java.io.IOException;
-
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
+import java.util.Map;
 
 import org.apache.uniffle.common.rpc.StatusCode;
-import org.apache.uniffle.common.util.RssUtils;
 
 public class RssGetShuffleResultResponse extends ClientResponse {
 
-  private Roaring64NavigableMap blockIdBitmap;
+  private Map<Long, Integer> blocks;
 
-  public RssGetShuffleResultResponse(StatusCode statusCode, byte[] serializedBitmap)
-      throws IOException {
+  public RssGetShuffleResultResponse(StatusCode statusCode, Map<Long, Integer> blocks) {
     super(statusCode);
-    blockIdBitmap = RssUtils.deserializeBitMap(serializedBitmap);
+    this.blocks = blocks;
   }
 
-  public Roaring64NavigableMap getBlockIdBitmap() {
-    return blockIdBitmap;
+  public Map<Long, Integer> getBlocks() {
+    return blocks;
   }
 }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -125,13 +125,7 @@ message ReportShuffleResultRequest {
   string appId = 1;
   int32 shuffleId = 2;
   int64 taskAttemptId = 3;
-  int32 bitmapNum = 4;
-  repeated PartitionToBlockIds partitionToBlockIds = 5;
-}
-
-message PartitionToBlockIds {
-  int32 partitionId = 1;
-  repeated int64 blockIds = 2;
+  map<int32, int32> partitionToBlocks = 4;
 }
 
 message ReportShuffleResultResponse {
@@ -143,32 +137,29 @@ message GetShuffleResultRequest {
   string appId = 1;
   int32 shuffleId = 2;
   int32 partitionId = 3;
-  BlockIdLayout blockIdLayout = 4;
-}
-
-message BlockIdLayout {
-  int32 sequenceNoBits = 1;
-  int32 partitionIdBits = 2;
-  int32 taskAttemptIdBits = 3;
 }
 
 message GetShuffleResultResponse {
   StatusCode status = 1;
   string retMsg = 2;
-  bytes serializedBitmap = 3;
+  map<int64, int32> taskAttemptBlocks = 3;
 }
 
 message GetShuffleResultForMultiPartRequest {
   string appId = 1;
   int32 shuffleId = 2;
   repeated int32 partitions = 3;
-  BlockIdLayout blockIdLayout = 4;
 }
 
 message GetShuffleResultForMultiPartResponse {
   StatusCode status = 1;
   string retMsg = 2;
-  bytes serializedBitmap = 3;
+  repeated TaskAttemptPartitionBlock taskAttemptBlocks = 3;
+}
+
+message TaskAttemptPartitionBlock {
+  int64 taskAttemptId = 1;
+  map<int32, int32> partitionBlocks = 2;
 }
 
 message ShufflePartitionRange {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, each individual block id is reported to shuffle servers by writer and retrieved by readers. Alternatively, the number of blocks per partition can be used to reconstruct all block ids.

### Why are the changes needed?

This removes the need to transfer serialized bitmaps. This is a step towards #1621.

Fix: #1399

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit and integration tests.